### PR TITLE
chore: pin publish action ref

### DIFF
--- a/.github/workflows/publish-nodepack.yml
+++ b/.github/workflows/publish-nodepack.yml
@@ -20,6 +20,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Publish Custom Node
-        uses: Comfy-Org/publish-node-action@main
+        uses: Comfy-Org/publish-node-action@d2366e7abb6ab16f3bb03e3520ae25c8cf749bc9
         with:
           personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin `Comfy-Org/publish-node-action` to the current upstream commit instead of the mutable `main` branch ref.
- Preserve current publish-action behavior while removing branch-retarget risk from the registry publish workflow.

## Verification
- `git ls-remote https://github.com/Comfy-Org/publish-node-action.git refs/heads/main` -> `d2366e7abb6ab16f3bb03e3520ae25c8cf749bc9`
- `python -m py_compile` over `__init__.py`, `utils.py`, and `nodes/*.py` using a PowerShell-expanded file list
- `python -m unittest discover -s tests` -> 11 tests passed
- `node --check web/index.js`, `web/js/lora_switcher.js`, `web/js/llm_aio.js`
- `python -m pip install -r requirements.txt --dry-run --upgrade`
- `rg uses:\s+.*@main .github\workflows` -> no mutable `@main` workflow refs
- `git diff --check` -> OK; Windows autocrlf warning only

## Public Model Identifier Gate
PASS. The candidate diff is workflow-only and does not change model-bearing code, artifacts, fixtures, or logs.